### PR TITLE
Feat. create Entity issue #4

### DIFF
--- a/src/main/java/com/kjo/talkpost/entity/BaseEntity.java
+++ b/src/main/java/com/kjo/talkpost/entity/BaseEntity.java
@@ -1,0 +1,19 @@
+package com.kjo.talkpost.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.Getter;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+  @CreatedDate private LocalDateTime createdAt;
+}

--- a/src/main/java/com/kjo/talkpost/entity/Chat.java
+++ b/src/main/java/com/kjo/talkpost/entity/Chat.java
@@ -1,0 +1,37 @@
+package com.kjo.talkpost.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+
+import org.springframework.data.annotation.LastModifiedDate;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "chat")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Chat extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "chat_id", nullable = false)
+  private Long chatId;
+
+  @Column(name = "chat_content", columnDefinition = "TEXT", nullable = false)
+  private String chatContent;
+
+  @Column(name = "chat_like", nullable = false)
+  private Long chatLike = 0L;
+
+  @LastModifiedDate private LocalDateTime updateAt;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "chatroom_id", nullable = false)
+  private ChatRoom chatRoom;
+}

--- a/src/main/java/com/kjo/talkpost/entity/ChatRoom.java
+++ b/src/main/java/com/kjo/talkpost/entity/ChatRoom.java
@@ -1,0 +1,25 @@
+package com.kjo.talkpost.entity;
+
+import jakarta.persistence.*;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "chat_room")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoom extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "chatroom_id", nullable = false)
+  private Long chatroomId;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "post_id", nullable = false)
+  private Post post;
+}

--- a/src/main/java/com/kjo/talkpost/entity/Member.java
+++ b/src/main/java/com/kjo/talkpost/entity/Member.java
@@ -1,0 +1,34 @@
+package com.kjo.talkpost.entity;
+
+import jakarta.persistence.*;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "post")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "member_id", nullable = false)
+  private Long memberId;
+
+  @Column(name = "email", length = 40, nullable = false)
+  private String email;
+
+  @Column(name = "password", length = 255, nullable = false)
+  private String password;
+
+  @Column(name = "nickname", length = 10, nullable = false)
+  private String nickname;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "socialType", nullable = false)
+  private SocialType socialType;
+}

--- a/src/main/java/com/kjo/talkpost/entity/Post.java
+++ b/src/main/java/com/kjo/talkpost/entity/Post.java
@@ -1,0 +1,40 @@
+package com.kjo.talkpost.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+
+import org.springframework.data.annotation.LastModifiedDate;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "post")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "member_id", nullable = false)
+  private Long postId;
+
+  @Column(name = "title", length = 50, nullable = false)
+  private String title;
+
+  @Column(name = "post_content", columnDefinition = "TEXT", nullable = false)
+  private String postContent;
+
+  @Column(name = "post_like", nullable = false)
+  private Long postLike = 0L;
+
+  @LastModifiedDate private LocalDateTime updateAt;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+}

--- a/src/main/java/com/kjo/talkpost/entity/SocialType.java
+++ b/src/main/java/com/kjo/talkpost/entity/SocialType.java
@@ -1,0 +1,7 @@
+package com.kjo.talkpost.entity;
+
+public enum SocialType {
+  EMAIL,
+  NAVER,
+  KAKAO
+}


### PR DESCRIPTION
issue #4

엔티티 생성

NoArg, AllArg -> AccessLevel.PROTECTED

추후에 테이블과 컬럼 명이 수정되었을 때 간단하게 수정하기 위해 각각 이름을 명시해둠 

Post -> ManyToOne
ChatRoom -> OneToOne
Chat -> ManyToOne

BaseEntity에는 createdAt 만

Post에만 updateAt 추가 


추후에 N+1 검증 후 개선 필요